### PR TITLE
Bug: ScheduleItem 데이터 받아올 때 서로 다른 데이터 참조하는 이슈 #50

### DIFF
--- a/src/components/common/ScheduleItem/ScheduleItem.jsx
+++ b/src/components/common/ScheduleItem/ScheduleItem.jsx
@@ -25,6 +25,7 @@ const ScheduleItem = ({
     return getDay;
   };
 
+
   const renderStatusToAdmin = (scheduleData, index) => {
     const { status, numWorkers } = scheduleData;
     switch (status) {
@@ -45,12 +46,11 @@ const ScheduleItem = ({
 
   const renderStatusToStaff = (scheduleData, index, fetchBookedShifts) => {
     const { status } = scheduleData;
-    const { role } = fetchBookedShifts;
     if (status === "모집중") {
       return <Badge>대기중</Badge>;
-    } else if (status === "모집완료" && role === "") {
+    } else if (status === "모집완료" && !fetchBookedShifts[index].role) {
       return <Badge colorScheme="red">취소됨</Badge>;
-    } else if (status === "모집완료") {
+    } else if (status === "모집완료" && fetchBookedShifts[index].role) {
       return <Badge colorScheme="green">확정</Badge>;
     }
   };
@@ -78,7 +78,7 @@ const ScheduleItem = ({
                     : renderStatusToStaff(
                         scheduleData,
                         index,
-                        fetchBookedShifts[index],
+                        fetchBookedShifts,
                       )}
                 </div>
               </style.ScheduleStatus>

--- a/src/pages/Dashboard/staff/Dashboard_S.jsx
+++ b/src/pages/Dashboard/staff/Dashboard_S.jsx
@@ -42,14 +42,18 @@ const Dashboard_S = () => {
         }
       });
 
+      
       setFetchNoticeData(getNoticeData);
-      setFetchBookedShifts(getBookedShiftsData);
       setFetchScheduleData(getScheduleData);
       setMatchedData(matchData);
-      setSliceMatchData(matchData.slice(0, 3));
-      console.log(fetchBookedShifts);
+      
+      const sortedSliceMatchData = matchData.sort((a, b) => b.id.localeCompare(a.id));
+      const sortedFetchBookedShifts = getBookedShiftsData.sort((a, b) => b.scheduleId.localeCompare(a.scheduleId));
+      
+      setSliceMatchData(sortedSliceMatchData);
+      setFetchBookedShifts(sortedFetchBookedShifts);
 
-      const dataArr = [];
+      const dataArr = []; 
       const confirmDataArr = [];
 
       for (const item of getBookedShiftsData) {
@@ -63,29 +67,13 @@ const Dashboard_S = () => {
           (item) => scheduleData.id === item.scheduleId,
         );
 
-        if (matchingItem) {
+        if (matchingItem && scheduleData.status === '모집완료') {
           confirmDataArr.push(scheduleData);
         }
       });
 
       setConfirmedData(confirmDataArr);
-
-      // 이상 없으면 제거
-      // for (const secondItem of bookingShiftsData) {
-      //   const scheduleId = secondItem.scheduleId;
-
-      //   const matchingFirstItem = getScheduleData.find(
-      //     (firstItem) => firstItem.id === scheduleId,
-      //   );
-
-      //   if (matchingFirstItem) {
-      //     const newObject = {
-      //       ...matchingFirstItem,
-      //     };
-
-      //     matchingData.push(newObject);
-      //   }
-      // }
+      console.log(confirmedData)
       setLoading(false);
     };
 


### PR DESCRIPTION
두 데이터들의 인덱스 값이 달라서 map 메서드 안에서 데이터가 돌 때 참조하는 데이터가 서로 다르게 바인딩 되는 이슈가 있었습니다.

데이터를 받아오고 scheduleItem 으로 props 내려주는 scheduleLists, fetchBookedShifts 데이터의

순서를 정렬하여 매치를 해줘서 해결하였습니다. 확인 부탁드리겠습니다.
